### PR TITLE
Outdated lockfile prevents dependency installation

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       lucide-react:
         specifier: ^0.510.0
         version: 0.510.0(react@19.1.0)
+      monaco-editor:
+        specifier: ^0.47.0
+        version: 0.47.0
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2135,6 +2138,9 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  monaco-editor@0.47.0:
+    resolution: {integrity: sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==}
 
   motion-dom@12.15.0:
     resolution: {integrity: sha512-D2ldJgor+2vdcrDtKJw48k3OddXiZN1dDLLWrS8kiHzQdYVruh0IoTwbJBslrnTXIPgFED7PBN2Zbwl7rNqnhA==}
@@ -4510,6 +4516,8 @@ snapshots:
       minipass: 7.1.2
 
   mkdirp@3.0.1: {}
+
+  monaco-editor@0.47.0: {}
 
   motion-dom@12.15.0:
     dependencies:


### PR DESCRIPTION
Update pnpm-lock.yaml to fix deployment failure caused by outdated lockfile.

The `pnpm-lock.yaml` was out of sync with `package.json`, specifically missing the `monaco-editor` dependency. This led to `ERR_PNPM_OUTDATED_LOCKFILE` during `pnpm install --frozen-lockfile` in CI environments. Regenerating the lockfile resolves this dependency mismatch.